### PR TITLE
fix changes in bun-utilities

### DIFF
--- a/src/os/darwin.ts
+++ b/src/os/darwin.ts
@@ -1,4 +1,4 @@
-import { exec } from 'bun-utilities'
+import { exec } from 'bun-utilities/spawn'
 
 const getWifiName = () => {
   const cmd =

--- a/src/os/linux.ts
+++ b/src/os/linux.ts
@@ -1,4 +1,4 @@
-import { exec } from 'bun-utilities'
+import { exec } from 'bun-utilities/spawn'
 
 const getWifiName = () => {
   const { stdout } = exec(['iwgetid', '--raw'])

--- a/src/os/win32.ts
+++ b/src/os/win32.ts
@@ -1,4 +1,4 @@
-import { exec } from 'bun-utilities'
+import { exec } from 'bun-utilities/spawn'
 
 const getWifiName = () => {
   const { stdout } = exec(['netsh', 'wlan', 'show', 'interface'])


### PR DESCRIPTION
`bun-utilities` 0.2.0 had a change to the location of where to import `exec()` from.